### PR TITLE
Add defcustom for the path to the shellcheck executable

### DIFF
--- a/flymake-shellcheck.el
+++ b/flymake-shellcheck.el
@@ -1,6 +1,7 @@
 ;;; flymake-shellcheck.el --- A bash/sh Flymake backend powered by ShellCheck  -*- lexical-binding: t; -*-
 
 ;; Copyright (c) 2018 Federico Tedin
+;; Copyright (c) 2020 Joseph LaFreniere (lafrenierejm) <joseph@lafreniere.xyz>
 
 ;; Author: Federico Tedin <federicotedin@gmail.com>
 ;; Homepage: https://github.com/federicotdn/flymake-shellcheck

--- a/flymake-shellcheck.el
+++ b/flymake-shellcheck.el
@@ -35,12 +35,18 @@
   :prefix "flymake-shellcheck-"
   :group 'tools)
 
+(defcustom flymake-shellcheck-path
+  (executable-find "shellcheck")
+  "The path to the `shellcheck' executable."
+  :type 'string)
+
 (defvar-local flymake-shellcheck--proc nil)
 
 (defun flymake-shellcheck--backend (report-fn &rest _args)
   "Shellcheck backend for Flymake.  Check for problems, then call REPORT-FN with results."
-  (unless (executable-find
-           "shellcheck") (error "Could not find shellcheck executable"))
+  (unless (and flymake-shellcheck-path
+               (file-executable-p flymake-shellcheck-path))
+    (error "Could not find shellcheck executable"))
 
   (when (process-live-p flymake-shellcheck--proc)
     (kill-process flymake-shellcheck--proc))
@@ -54,7 +60,7 @@
        (make-process
         :name "shellcheck-flymake" :noquery t :connection-type 'pipe
         :buffer (generate-new-buffer " *shellcheck-flymake*")
-        :command (list "shellcheck" "-f" "gcc" filename)
+        :command (list flymake-shellcheck-path "-f" "gcc" filename)
         :sentinel
         (lambda (proc _event)
           (when (eq 'exit (process-status proc))

--- a/flymake-shellcheck.el
+++ b/flymake-shellcheck.el
@@ -30,6 +30,11 @@
 
 ;;; Code:
 
+(defgroup flymake-shellcheck nil
+  "Shellcheck backend for Flymake."
+  :prefix "flymake-shellcheck-"
+  :group 'tools)
+
 (defvar-local flymake-shellcheck--proc nil)
 
 (defun flymake-shellcheck--backend (report-fn &rest _args)


### PR DESCRIPTION
This makes it possible to specify path that's not in `PATH`, which is useful when using e.g. Nix or Guix.