### PR TITLE
Add 'flymake-shellcheck-allow-external-files'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ After opening a shell/sh file, remember to enable Flymake:
 
 - You can set the `flymake-shellcheck-path` variable to the path of the ShellCheck executable in your system, in case `executable-find` wasn't able to find it automatically.
 - You can set the `flymake-shellcheck-use-file` variable to `nil` if you wish to run the syntax checker on the contents of the buffer, rather than the contents of the file on disk (default: `t`).
+- You can set the `flymake-shellcheck-allow-external-files` variable to `t` if you want to allow shellcheck to read external sources (it adds `-x` as argument, described in [the SC1091 docs](https://github.com/koalaman/shellcheck/wiki/SC1091), default: `nil`).
 
 ## License
 

--- a/flymake-shellcheck.el
+++ b/flymake-shellcheck.el
@@ -50,6 +50,11 @@ Setting this variable to non-nil may yield slightly quicker syntax
 checks on very large files."
   :type 'boolean)
 
+(defcustom flymake-shellcheck-allow-external-files nil
+  "When non-nil, allow shellcheck to source external files with the '-x' parameter.
+Otherwise, external files won't be sourced."
+  :type 'boolean)
+
 (defvar-local flymake-shellcheck--proc nil)
 
 (defun flymake-shellcheck--backend (report-fn &rest _args)
@@ -71,9 +76,10 @@ checks on very large files."
        (make-process
         :name "shellcheck-flymake" :noquery t :connection-type 'pipe
         :buffer (generate-new-buffer " *shellcheck-flymake*")
-        :command (list flymake-shellcheck-path
+        :command (remove nil (list flymake-shellcheck-path
                        "-f" "gcc"
-                       (if flymake-shellcheck-use-file filename "-"))
+                       (if flymake-shellcheck-allow-external-files "-x")
+                       (if flymake-shellcheck-use-file filename "-")))
         :sentinel
         (lambda (proc _event)
           (when (eq 'exit (process-status proc))


### PR DESCRIPTION
This adds a configuration parameter which - when enabled - runs shellcheck with the option `-x` so that external files are allowed.
That parameter is necessary if `source x` is being used (https://github.com/koalaman/shellcheck/wiki/SC1091).

I'm not really fluent in elisp, so if there is a better way than using the `(remove nil..` I'd be glad to know it :)